### PR TITLE
Update Utils.php

### DIFF
--- a/classes/Utils.php
+++ b/classes/Utils.php
@@ -74,7 +74,7 @@ class Utils
         if (in_array(mb_strtolower($currency->iso_code), Stripe::$zeroDecimalCurrencies)) {
             return (int)$amount;
         }
-        return (int)($amount * 100);
+        return (int)round($amount * 100);
     }
 
     /**


### PR DESCRIPTION
Sometimes in my shop I get invalid total to pay value, which is caused by direct (int) conversion - using round fn before it, fixes "off by one" values.