### PR TITLE
Fixes on partial refund

### DIFF
--- a/stripe.php
+++ b/stripe.php
@@ -2473,8 +2473,11 @@ class Stripe extends PaymentModule
                     case 'three_d_secure':
                         $result['source_type'] = $this->l('3D Secure');
                         break;
-                    default:
+                    case 'cc':
                         $result['source_type'] = $this->l('Credit Card');
+                        break;
+                    default:
+                        $result['source_type'] = $this->l('Unknown');
                         break;
                 }
 

--- a/stripe.php
+++ b/stripe.php
@@ -432,7 +432,7 @@ class Stripe extends PaymentModule
             Tools::redirectAdmin($this->context->link->getAdminLink('AdminOrders', true).'&vieworder&id_order='.$idOrder);
         }
 
-        $amount = (float) Tools::getValue('stripe_refund_amount');
+        $amount = (float) Tools::parseNumber(Tools::getValue('stripe_refund_amount'));
 
         $idCharge = StripeTransaction::getChargeByIdOrder($idOrder);
         $order = new Order($idOrder);


### PR DESCRIPTION
Fixes two issues with partial refund

- Comma is not accepted as decimal separator
- Back end always shows “Credit card” as payment method for refunds