### PR TITLE
Added Stripe-Version header to fix incompatibility

### DIFF
--- a/stripe.php
+++ b/stripe.php
@@ -165,7 +165,7 @@ class Stripe extends PaymentModule
     {
         $this->name = 'stripe';
         $this->tab = 'payments_gateways';
-        $this->version = '1.7.1';
+        $this->version = '1.7.1-p1';
         $this->author = 'thirty bees';
         $this->need_instance = 0;
 


### PR DESCRIPTION
Closes #56 because every request includes the necessary API version. Ideally the API code should just be updated to conform to a newer API version at some point.

This just fixed my installation. I was having the problem described here:

https://forum.thirtybees.com/topic/5785-stripe-has-release-new-api-version-not-compatible-with-tb-module/