### PR TITLE
Replace image reference from stripebtnlogo to creditcards

### DIFF
--- a/classes/PaymentMethod/CardFormMethod.php
+++ b/classes/PaymentMethod/CardFormMethod.php
@@ -56,7 +56,7 @@ class CardFormMethod extends PaymentMethod
      */
     public function getImageFile(): string
     {
-        return 'stripebtnlogo.png';
+        return 'creditcards.png';
     }
 
     /**

--- a/classes/PaymentMethod/CheckoutMethod.php
+++ b/classes/PaymentMethod/CheckoutMethod.php
@@ -55,7 +55,7 @@ class CheckoutMethod extends PaymentMethod
      */
     public function getImageFile(): string
     {
-        return 'stripebtnlogo.png';
+        return 'creditcards.png';
     }
 
     /**


### PR DESCRIPTION
See https://forum.thirtybees.com/topic/6838-changing-stripe-module-stripe-logo-with-credit-card-logo/

Many customers do not actually read the text of the various payment methods but just look at the symbols. Which is why many do not realise we offer credit card payments and are unhappy. I think it would be a good idea to change the Stripe module logo with a credit card logo. 